### PR TITLE
feat: Implement main screen with bottom navigation

### DIFF
--- a/app/src/main/java/com/example/tokengenerator/MainActivity.kt
+++ b/app/src/main/java/com/example/tokengenerator/MainActivity.kt
@@ -3,13 +3,13 @@ package com.example.tokengenerator
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import com.example.tokengenerator.ui.screen.AddOrEditPersonScreen
+import com.example.tokengenerator.ui.screen.MainScreen
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            AddOrEditPersonScreen()
+            MainScreen()
         }
     }
 }

--- a/app/src/main/java/com/example/tokengenerator/constant/Constant.kt
+++ b/app/src/main/java/com/example/tokengenerator/constant/Constant.kt
@@ -1,0 +1,7 @@
+package com.example.tokengenerator.constant
+
+object Constant {
+    const val GENERATE_TOKEN: String = "GENERATE_TOKEN"
+    const val MODIFY_REFERENCE_PERSONS: String = "MODIFY_REFERENCE_PERSONS"
+    const val VIEW_REPORT: String = "VIEW_REPORT"
+}

--- a/app/src/main/java/com/example/tokengenerator/dataClass/NavItem.kt
+++ b/app/src/main/java/com/example/tokengenerator/dataClass/NavItem.kt
@@ -1,0 +1,10 @@
+package com.example.tokengenerator.dataClass
+
+import androidx.compose.ui.graphics.vector.ImageVector
+
+data class NavItem(
+    val title: String,
+    val icon: ImageVector,
+    val route: String
+
+)

--- a/app/src/main/java/com/example/tokengenerator/ui/screen/GenerateTokenScreen.kt
+++ b/app/src/main/java/com/example/tokengenerator/ui/screen/GenerateTokenScreen.kt
@@ -1,0 +1,10 @@
+package com.example.tokengenerator.ui.screen
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun GenerateTokenScreen(modifier: Modifier = Modifier) {
+    Text("Generate Token Screen")
+}

--- a/app/src/main/java/com/example/tokengenerator/ui/screen/MainScreen.kt
+++ b/app/src/main/java/com/example/tokengenerator/ui/screen/MainScreen.kt
@@ -1,0 +1,72 @@
+package com.example.tokengenerator.ui.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.example.tokengenerator.constant.Constant.GENERATE_TOKEN
+import com.example.tokengenerator.constant.Constant.MODIFY_REFERENCE_PERSONS
+import com.example.tokengenerator.constant.Constant.VIEW_REPORT
+import com.example.tokengenerator.dataClass.NavItem
+
+
+val navItems = listOf(
+    NavItem(title = "Token", icon = Icons.Default.Add, route = GENERATE_TOKEN),
+    NavItem(title = "Persons", icon = Icons.Default.Person, route = MODIFY_REFERENCE_PERSONS),
+    NavItem(title = "Report", icon = Icons.Default.Menu, route = VIEW_REPORT),
+)
+
+@Composable
+fun MainScreen(modifier: Modifier = Modifier) {
+
+    var selectedNavIndex by remember { mutableIntStateOf(0) }
+
+    Scaffold (
+        modifier = modifier.fillMaxSize(),
+        bottomBar = {
+            NavigationBar {
+                navItems.forEachIndexed { index, item ->
+                    NavigationBarItem(
+                        selected = index == selectedNavIndex,
+                        onClick = {
+                            selectedNavIndex = index
+                        },
+                        label = { Text(item.title) },
+                        icon = { Icon(item.icon, contentDescription = item.title) }
+                    )
+                }
+            }
+        }
+    ) {
+        innerPadding -> Box(modifier = modifier.padding(innerPadding)) { ContentScreen(selectedNavIndex = selectedNavIndex)}
+    }
+}
+
+@Composable
+fun ContentScreen(selectedNavIndex: Int) {
+        when (navItems[selectedNavIndex].route) {
+            GENERATE_TOKEN -> {
+                GenerateTokenScreen()
+            }
+            MODIFY_REFERENCE_PERSONS -> {
+                AddOrEditPersonScreen()
+            }
+            VIEW_REPORT -> {
+                ViewReportScreen()
+            }
+        }
+}

--- a/app/src/main/java/com/example/tokengenerator/ui/screen/ViewReportScreen.kt
+++ b/app/src/main/java/com/example/tokengenerator/ui/screen/ViewReportScreen.kt
@@ -1,0 +1,10 @@
+package com.example.tokengenerator.ui.screen
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ViewReportScreen(modifier: Modifier = Modifier) {
+    Text("View Report Screen")
+}


### PR DESCRIPTION
This commit introduces the main screen of the application, featuring a bottom navigation bar for switching between different sections.

Key changes:
- Created `MainScreen.kt` which sets up a `Scaffold` with a `NavigationBar`.
- The `NavigationBar` displays three items: "Token", "Persons", and "Report", using icons from `Material.Icons`.
- Navigation logic is handled by `ContentScreen`, which displays the appropriate screen based on the selected navigation item.
- Created placeholder screens: `GenerateTokenScreen.kt` and `ViewReportScreen.kt`.
- Updated `MainActivity.kt` to display `MainScreen` as the entry point.
- Added `NavItem.kt` data class to represent navigation items (title, icon, route).
- Defined navigation route constants in `Constant.kt`.

Closed: #7 