### PR TITLE
feat: Implement Token generation and printing functionality

### DIFF
--- a/app/src/main/java/com/example/tokengenerator/data/Converters.kt
+++ b/app/src/main/java/com/example/tokengenerator/data/Converters.kt
@@ -1,0 +1,16 @@
+package com.example.tokengenerator.data
+
+import androidx.room.TypeConverter
+import java.util.Date
+
+object Converters {
+    @TypeConverter
+    fun fromTimestamp(value: Long?): Date? {
+        return value?.let { Date(it) }
+    }
+
+    @TypeConverter
+    fun dateToTimestamp(date: Date?): Long? {
+        return date?.time
+    }
+}

--- a/app/src/main/java/com/example/tokengenerator/data/Token.kt
+++ b/app/src/main/java/com/example/tokengenerator/data/Token.kt
@@ -1,0 +1,26 @@
+package com.example.tokengenerator.data
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.util.Date
+
+@Entity(
+    tableName = "tokens",
+    indices = [Index(value = ["personId"])],
+    foreignKeys = [
+        ForeignKey(
+            entity = Person::class,
+            parentColumns = ["id"],
+            childColumns = ["personId"],
+            onDelete = ForeignKey.NO_ACTION
+        )
+    ]
+)
+data class Token(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val personId: Int,
+    val noOfPerson: Int,
+    val issuedOn: Date = Date()
+)

--- a/app/src/main/java/com/example/tokengenerator/data/TokenDAO.kt
+++ b/app/src/main/java/com/example/tokengenerator/data/TokenDAO.kt
@@ -1,0 +1,26 @@
+package com.example.tokengenerator.data
+
+import androidx.lifecycle.LiveData
+import androidx.room.*
+
+@Dao
+interface TokenDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(token: Token): Long
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(tokens: List<Token>): List<Long>
+
+    @Update
+    suspend fun update(token: Token)
+
+    @Delete
+    suspend fun delete(token: Token)
+
+    @Query("SELECT * FROM tokens ORDER BY id DESC")
+    fun getAllTokens(): LiveData<List<Token>>
+
+    @Query("SELECT * FROM tokens WHERE id IN (:tokenIds)")
+    suspend fun getTokensByIds(tokenIds: List<Long>): List<Token>
+}

--- a/app/src/main/java/com/example/tokengenerator/repository/TokenRepository.kt
+++ b/app/src/main/java/com/example/tokengenerator/repository/TokenRepository.kt
@@ -1,0 +1,30 @@
+package com.example.tokengenerator.repository
+
+import androidx.lifecycle.LiveData
+import com.example.tokengenerator.data.Token
+import com.example.tokengenerator.data.TokenDao
+
+class TokenRepository(private val tokenDao: TokenDao) {
+
+    val allTokens: LiveData<List<Token>> = tokenDao.getAllTokens()
+
+    suspend fun insert(token: Token): Long {
+        return tokenDao.insert(token)
+    }
+
+    suspend fun insertAll(tokens: List<Token>): List<Long> {
+        return tokenDao.insertAll(tokens)
+    }
+
+    suspend fun update(token: Token) {
+        tokenDao.update(token)
+    }
+
+    suspend fun delete(token: Token) {
+        tokenDao.delete(token)
+    }
+
+    suspend fun getTokensByIds(tokenIds: List<Long>): List<Token> {
+        return tokenDao.getTokensByIds(tokenIds)
+    }
+}

--- a/app/src/main/java/com/example/tokengenerator/viewmodel/TokenViewModel.kt
+++ b/app/src/main/java/com/example/tokengenerator/viewmodel/TokenViewModel.kt
@@ -1,0 +1,60 @@
+package com.example.tokengenerator.viewmodel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.viewModelScope
+import com.example.tokengenerator.data.Token
+import com.example.tokengenerator.data.AppDatabase
+import com.example.tokengenerator.repository.TokenRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class TokenViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val _newlyAddedTokens = MutableStateFlow<List<Token>>(emptyList())
+    val newlyAddedTokens = _newlyAddedTokens.asStateFlow()
+    private val repository: TokenRepository
+    val allTokens: LiveData<List<Token>>
+
+    init {
+        val dao = AppDatabase.getInstance(application).tokenDao()
+        repository = TokenRepository(dao)
+        allTokens = repository.allTokens
+    }
+
+    fun insert(token: Token) {
+        viewModelScope.launch {
+            repository.insert(token)
+        }
+    }
+
+    fun insertAll(tokens: List<Token>) {
+        viewModelScope.launch {
+            val insertedIds = repository.insertAll(tokens)
+            val addedTokens = getTokensByIds(insertedIds)
+            _newlyAddedTokens.value = addedTokens
+        }
+    }
+
+    fun update(token: Token) {
+        viewModelScope.launch {
+            repository.update(token)
+        }
+    }
+
+    fun delete(token: Token) {
+        viewModelScope.launch {
+            repository.delete(token)
+        }
+    }
+
+    suspend fun getTokensByIds(tokenIds: List<Long>): List<Token> {
+        return repository.getTokensByIds(tokenIds)
+    }
+
+    fun clearNewlyAddedTokens() {
+        _newlyAddedTokens.value = emptyList()
+    }
+}


### PR DESCRIPTION
This commit introduces the ability to generate and print tokens for individuals.

Key changes include:

- **Token Data Model:**
    - Added a `Token` data class (`app/src/main/java/com/example/tokengenerator/data/Token.kt`) with fields for `id`, `personId`, `noOfPerson`, and `issuedOn`.
    - Implemented a `TokenDao` (`app/src/main/java/com/example/tokengenerator/data/TokenDAO.kt`) for database operations related to tokens.
    - Created a `TokenRepository` (`app/src/main/java/com/example/tokengenerator/repository/TokenRepository.kt`) to abstract data source access for tokens.
    - Developed a `TokenViewModel` (`app/src/main/java/com/example/tokengenerator/viewmodel/TokenViewModel.kt`) to manage token-related UI logic and data.
    - Added `Converters.kt` for Room to handle `Date` type conversion.
    - Updated `AppDatabase.kt` to include the `Token` entity, its DAO, and a new migration (version 3 to 4) for the `tokens` table.

- **Token Generation and Printing Logic:**
    - Modified `PrintActivity.kt`: - `generateBitmapsForPrinting` now accepts a list of `Token` objects instead of a simple count, allowing each token to have unique data (like `issuedOn`). - `TokenUI` composable now takes a `Token` object as a parameter to display token-specific information (ID, number of persons, issued date). - `doPhotoPrint` now includes an `onDismiss` callback.
    - Updated `GenerateTokenScreen.kt`:
        - The "Generate & Print" popup now uses the `TokenViewModel` to insert new tokens into the database.
        - `GenerateTokens` composable was introduced to handle the creation and insertion of `Token` objects. - `generateTokenAndPrint` function now receives a list of `Token` objects to print. - The UI for the popup now displays "M. Id" instead of combining it with the person's name. - Logging has been added to trace token generation and printing.

- **UI Updates:**
    - The `TokenUI` composable now correctly formats and displays the `issuedOn` date for each token.
    - The "Generate Token" popup in `GenerateTokenScreen.kt` has been refined to show more specific person details.

This set of changes enables the core functionality of creating multiple tokens associated with a person, storing them in the local database, and then generating printable bitmap representations for each token.