### PR TITLE
Enable minification for release builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"


### PR DESCRIPTION
This commit updates the `app/build.gradle.kts` file to enable minification (`isMinifyEnabled = true`) for release build types. This helps reduce the size of the compiled application by removing unused code and resources.