### PR TITLE
feat: Request POST_NOTIFICATIONS permission on Android 13+

### DIFF
--- a/app/src/main/java/com/example/tokengenerator/MainActivity.kt
+++ b/app/src/main/java/com/example/tokengenerator/MainActivity.kt
@@ -1,15 +1,40 @@
 package com.example.tokengenerator
 
+import android.Manifest
+import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import com.example.tokengenerator.ui.screen.MainScreen
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
+            RequestPermissions()
             MainScreen()
         }
+    }
+}
+
+@Composable
+fun RequestPermissions() {
+    val permissionsList = mutableListOf<String>()
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        permissionsList.add(Manifest.permission.POST_NOTIFICATIONS)
+    }
+
+    val requestPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions(),
+        onResult = {
+            // Handle permission results here if needed
+        }
+    )
+    LaunchedEffect(true) {
+        requestPermissionLauncher.launch(permissionsList.toTypedArray())
     }
 }


### PR DESCRIPTION
This commit introduces a permission request for `POST_NOTIFICATIONS` on devices running Android 13 (API level 33) and higher.

A new composable function `RequestPermissions` has been added to `MainActivity.kt`. This function:
- Checks if the device is running Android 13 or later.
- If so, it adds `Manifest.permission.POST_NOTIFICATIONS` to a list of permissions to request.
- Uses `rememberLauncherForActivityResult` with `ActivityResultContracts.RequestMultiplePermissions` to request the necessary permissions.
- The permission request is launched using `LaunchedEffect`.

This change is necessary to comply with Android 13's runtime permission model for notifications.